### PR TITLE
#62 Organizer's Map Integration (Part 1)

### DIFF
--- a/backend/database/database.js
+++ b/backend/database/database.js
@@ -507,6 +507,20 @@ export async function getAllEventsOwned(session) {
   return org?.eventsOwned ?? [];
 }
 
+// Get events owned by a specific organization
+export async function getAllEventsOwnedByOrgId(orgId) {
+  try {
+    const org = await prisma.organization.findUnique({
+      where: { id: orgId },
+      include: { eventsOwned: true },
+    });
+    return org?.eventsOwned || [];
+  } catch (error) {
+    console.error("Failed to fetch events for organization:", error.message);
+    return [];
+  }
+}
+
 /**
  * Gets all the users registered to an event through the eventId
  * @param {Number} eventId 

--- a/backend/index.js
+++ b/backend/index.js
@@ -3,6 +3,7 @@ import cors from 'cors';
 import 'dotenv/config';
 import * as database from './database/database.js';
 import { generateQr, validateQr } from './database/qr.js';
+import prisma from "./database/prisma.js";
 
 const app = express();
 const PORT = process.env.PORT || 5001;
@@ -20,6 +21,21 @@ app.get("/api/getEvents", async (req, res) => {
     return res.status(500).json({ error: "Either no events or database error" });
   }
   res.json({ events });
+});
+
+// Get events owned by a specific organization
+app.get("/api/getEventsOwned/:orgId", async (req, res) => {
+  try {
+    const { orgId } = req.params;
+    const org = await database.getAllEventsOwnedByOrgId(Number(orgId));
+    if (!org || org.length === 0) {
+      return res.status(404).json({ error: "No events found for this organization" });
+    }
+    res.json({ events: org });
+  } catch (error) {
+    console.error("Error fetching org events:", error);
+    res.status(500).json({ error: "Database error fetching organization events" });
+  }
 });
 
 app.get("/api/admin/region-stats", async (_req, res) => {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -80,10 +80,11 @@ function App() {
           <Route path="/map" element={<MapView events={events} user={user} org={org} />} />
           <Route path="/registrations" element={<Discover events={events} user={user} org={org} isRegistrations={true} isMyEvent={false} />} />
           <Route path="/myEvents" element={<Discover events={events} user={user} org={org} isRegistrations={false} isMyEvent={true} />} />
+          <Route path="/myEvents/:id" element={<Discover events={events} user={user} org={org} isRegistrations={false} isMyEvent={true} />} />
           {/*<Route path="/qr/generate" element={<QrGenerate />} />*/}
           <Route path="/qr/scan" element={<QrScan />} />
           <Route path="/register" element={<TicketClaim setEvents={setEvents} user={user} setUser={setUser} />} />
-          <Route path="/moderate/users" element ={<UserModerations organizations={organizations} setOrganizations={setOrganizations} users={users} setUsers={setUsers} user={user} />} />
+          <Route path="/moderate/users" element={<UserModerations organizations={organizations} setOrganizations={setOrganizations} users={users} setUsers={setUsers} user={user} />} />
           <Route path="/login" element={<Login onLogin={handleLogin} setUser={setUser} org={org} setOrg={setOrg} setSession={setSession} />} />
           <Route path="/signup" element={<Signup />} />
         </Routes>

--- a/frontend/src/components/Account/Login.jsx
+++ b/frontend/src/components/Account/Login.jsx
@@ -50,7 +50,14 @@ const Login = ({ onLogin, setUser, org, setOrg, setSession }) => {
       setUser(data.user);
       setOrg(data.org);
       setIsLoggedIn(true);
-      localStorage.setItem("role", data.user.role);
+      if (data.user) {
+        localStorage.setItem("role", data.user.role);
+        localStorage.removeItem("isOrg");
+      } else if (data.org) {
+        localStorage.setItem("isOrg", "true");
+        localStorage.setItem("org", JSON.stringify(data.org));
+        localStorage.removeItem("role");
+      }
     } else {
       setMessage(data.error);
     }

--- a/frontend/src/components/Discover/Discover.jsx
+++ b/frontend/src/components/Discover/Discover.jsx
@@ -100,11 +100,17 @@ function Discover({ events, user, org, isRegistrations, isMyEvent }) {
   }
 
   const handleClose = () => {
-    setSelectedEvent(null);
+  setSelectedEvent(null);
+  setToken("");
+
+  if (isMyEvent) {
+    navigate("/myEvents");
+  } else if (isRegistrations) {
+    navigate("/registrations");
+  } else {
     navigate("/discover");
-    setToken("");
-    return;
   }
+};
 
   // format functions
   const formattedCost = (cost) => {

--- a/frontend/src/components/MapViews/MapView.jsx
+++ b/frontend/src/components/MapViews/MapView.jsx
@@ -1,24 +1,31 @@
 import StudentMapView from './StudentMapView';
 import AdminMapView from './AdminMapView';
+import OrganizerMapView from './OrganizerMapView';
 
 const MapView = () => {
-  // read the role saved in localStorage after login
+  // read stored data
   const storedRole = localStorage.getItem("role");
+  const isOrg = localStorage.getItem("isOrg") === "true"; // check if organizer logged in
 
-  // normalize Prisma roles to the app roles
+  // normalize user roles
   const normalized =
     storedRole === "USER" ? "student" :
     storedRole === "ADMIN" ? "admin" :
     null;
+
+  // organizer has no role (handeled separately)
+  if (isOrg) {
+    return <OrganizerMapView />;
+  }
 
   if (!normalized) {
     return <p>User role not defined. Please log in.</p>;
   }
 
   switch (normalized) {
-    case 'student':
+    case "student":
       return <StudentMapView />;
-    case 'admin':
+    case "admin":
       return <AdminMapView />;
     default:
       return <p>Invalid role. Please contact support.</p>;

--- a/frontend/src/components/MapViews/OrganizerMapView.jsx
+++ b/frontend/src/components/MapViews/OrganizerMapView.jsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useState } from "react";
+import { GoogleMap, Marker, InfoWindow, useJsApiLoader } from "@react-google-maps/api";
+import { useNavigate } from "react-router-dom";
+
+const containerStyle = {
+  width: "100%",
+  height: "80vh",
+  borderRadius: "12px",
+};
+
+const center = { lat: 45.5017, lng: -73.5673 };
+
+const OrganizerMapView = () => {
+  const { isLoaded } = useJsApiLoader({
+    googleMapsApiKey: process.env.REACT_APP_GOOGLE_MAPS_API_KEY,
+  });
+
+  const [events, setEvents] = useState([]);
+  const [selectedEvent, setSelectedEvent] = useState(null);
+  const navigate = useNavigate();
+
+  // Fetch events owned by the logged-in org
+  useEffect(() => {
+  const fetchEvents = async () => {
+    try {
+      const org = JSON.parse(localStorage.getItem("org"));
+      if (!org?.id) {
+        console.error("No organization found in localStorage");
+        return;
+      }
+      const res = await fetch(`http://localhost:5001/api/getEventsOwned/${org.id}`);
+      const data = await res.json();
+
+      if (data.events && data.events.length > 0) {
+        setEvents(data.events);
+      } else {
+        console.warn("No events found for this organization");
+      }
+    } catch (err) {
+      console.error("Error fetching organization events:", err);
+    }
+  };
+
+  fetchEvents();
+}, []);
+
+  if (!isLoaded) return <p>Loading map...</p>;
+
+  return (
+    <GoogleMap mapContainerStyle={containerStyle} center={center} zoom={13}>
+      {events.length > 0 ? (
+        events.map((event, i) => (
+          <Marker
+            key={i}
+            position={{
+              lat: Number(event.latitude || event.lat || 45.5017),
+              lng: Number(event.longitude || event.lng || -73.5673),
+            }}
+            onClick={() => setSelectedEvent(event)}
+          />
+        ))
+      ) : (
+        <p
+          style={{
+            position: "absolute",
+            top: "10px",
+            left: "50%",
+            transform: "translateX(-50%)",
+            backgroundColor: "rgba(255,255,255,0.8)",
+            padding: "8px 16px",
+            borderRadius: "8px",
+            boxShadow: "0 2px 8px rgba(0,0,0,0.2)",
+          }}
+        >
+          No events found for your organization
+        </p>
+      )}
+
+      {selectedEvent && (
+        <InfoWindow
+          position={{
+            lat: selectedEvent.latitude ?? 45.5017,
+            lng: selectedEvent.longitude ?? -73.5673,
+          }}
+          onCloseClick={() => setSelectedEvent(null)}
+        >
+          <div style={{ maxWidth: "220px" }}>
+            <h3 style={{ marginBottom: "6px", fontWeight: "600" }}>
+              {selectedEvent.title}
+            </h3>
+            <p style={{ fontSize: "14px", color: "#555" }}>
+              {selectedEvent.description?.slice(0, 80)}...
+            </p>
+            <button
+              onClick={() => navigate(`/myEvents/${selectedEvent.id}`)}
+              style={{
+                marginTop: "8px",
+                padding: "6px 10px",
+                borderRadius: "8px",
+                backgroundColor: "#007bff",
+                color: "#fff",
+                border: "none",
+                cursor: "pointer",
+              }}
+            >
+              View Details
+            </button>
+          </div>
+        </InfoWindow>
+      )}
+    </GoogleMap>
+  );
+};
+
+export default OrganizerMapView;


### PR DESCRIPTION
	•	Added OrganizerMapView.jsx to display only the logged-in organization’s events on the map.
	•	Added backend route /api/getEventsOwned/:orgId to fetch org-specific events.
	•	Updated MapView.jsx to detect organizer accounts via localStorage and load the correct view.
	•	Clicking an event marker now redirects to /myEvents/:id.
	•	Excludes events with missing coordinates.

closes #62 